### PR TITLE
Fix hour calculation bug in TimeUtil

### DIFF
--- a/src/main/java/com/mrcrayfish/device/util/TimeUtil.java
+++ b/src/main/java/com/mrcrayfish/device/util/TimeUtil.java
@@ -5,7 +5,7 @@ public class TimeUtil
 	public static String getTotalRealTime(long ticks)
 	{
 		int days = (int) (ticks / 1728000);
-		int hours = (int) Math.floor(ticks / 24000.0) % 24;
+		int hours = (int) Math.floor(ticks / 72000.0) % 24;
 	    int minutes = (int) Math.floor(ticks / 1200) % 60;
 	    int seconds = (int) Math.floor(ticks / 20) % 60;
 	    if(days > 0) 


### PR DESCRIPTION
## Summary
- fix incorrect hour calculation in `TimeUtil.getTotalRealTime`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683ff722bcf88327b9af654d495813c4